### PR TITLE
Add `NpmvDependencyExtension` with an ability to provide version cata…

### DIFF
--- a/kfc/kfc-gradle-plugin/src/main/kotlin/io/github/turansky/kfc/gradle/plugin/KotlinDefaults.kt
+++ b/kfc/kfc-gradle-plugin/src/main/kotlin/io/github/turansky/kfc/gradle/plugin/KotlinDefaults.kt
@@ -20,6 +20,7 @@ internal fun Project.applyKotlinDefaults() {
     plugins.apply(DisableSourcelessTestsPlugin::class)
 
     configureStrictMode()
+    configureNpmExtensions()
 }
 
 private fun Project.configureStrictMode() {

--- a/kfc/kfc-gradle-plugin/src/main/kotlin/io/github/turansky/kfc/gradle/plugin/NpmvDependencyExtension.kt
+++ b/kfc/kfc-gradle-plugin/src/main/kotlin/io/github/turansky/kfc/gradle/plugin/NpmvDependencyExtension.kt
@@ -1,0 +1,59 @@
+package io.github.turansky.kfc.gradle.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.the
+import org.jetbrains.kotlin.gradle.targets.js.npm.*
+import java.util.*
+import javax.inject.Inject
+
+private val EXTENSIONS = arrayOf(
+    NpmvDependencyExtension::class, // npmv
+    DevNpmvDependencyExtension::class, // devNpmv
+    PeerNpmvDependencyExtension::class, // peerNpmv
+)
+
+internal fun Project.configureNpmExtensions() {
+    for (pluginClass in EXTENSIONS) {
+        val extensionName = (pluginClass.simpleName ?: continue)
+            .removeSuffix("DependencyExtension")
+            .replaceFirstChar { it.lowercase(Locale.getDefault()) }
+
+        extensions.create(
+            name = extensionName,
+            type = pluginClass,
+        )
+    }
+}
+
+abstract class BaseNpmvDependencyExtension(
+    private val npmExt: Provider<BaseNpmDependencyExtension>,
+) {
+    // A way to declare NPM dependency from a version catalog
+    // Can be removed after an issue is fixed in KGP
+    // Issue: https://youtrack.jetbrains.com/issue/KT-48519/KJS-Add-npm-dependency-method-for-version-catalog
+    operator fun invoke(dependency: Provider<MinimalExternalModuleDependency>): Provider<NpmDependency> {
+        val ext = npmExt.get()
+        return dependency.map { ext(it.name, requireNotNull(it.version)) }
+    }
+}
+
+abstract class NpmvDependencyExtension
+@Inject constructor(val project: Project) :
+    BaseNpmvDependencyExtension(
+        project.provider { project.dependencies.the<NpmDependencyExtension>() }
+    )
+
+abstract class DevNpmvDependencyExtension
+@Inject constructor(val project: Project) :
+    BaseNpmvDependencyExtension(
+        project.provider { project.dependencies.the<DevNpmDependencyExtension>() }
+    )
+
+abstract class PeerNpmvDependencyExtension
+@Inject constructor(val project: Project) :
+    BaseNpmvDependencyExtension(
+        project.provider { project.dependencies.the<PeerNpmDependencyExtension>() }
+    )


### PR DESCRIPTION
Add `NpmvDependencyExtension` with an ability to provide version catalog dependencies

Example:
TOML file with dev dependency for rollup-plugin-visualizer

instead of `jsMainImplementation(devNpm("rollup-plugin-visualizer", "latest"))`
we will be able to use `jsMainImplementation(devNpmv(libs.rollup.plugin.visualizer))`

Link to YT issue: https://youtrack.jetbrains.com/issue/KT-48519/KJS-Add-npm-dependency-method-for-version-catalog